### PR TITLE
🔀 :: 반환하는 파일 확장자 변경

### DIFF
--- a/src/main/kotlin/com/project/indistraw/domain/file/application/service/FileUploadService.kt
+++ b/src/main/kotlin/com/project/indistraw/domain/file/application/service/FileUploadService.kt
@@ -35,8 +35,8 @@ class FileUploadService(
         } catch (e: IOException) {
             throw IllegalStateException("파일 업로드에 실패하였습니다.")
         }
-
-        return fileName
+        val hlsFileName = fileName.substring(0, fileName.indexOf("."))
+        return "$hlsFileName/Default/HLS/$hlsFileName.m3u8"
     }
 
     private fun createFileName(fileName: String) =


### PR DESCRIPTION
+ aws mediaconvert를 사용해서 입력받은 파일 확장자를 `.hls` 확장자로 변경시키는 작업을 했습니다.
+ 반환하는 파일의 확장자를 `.hls` 파일 확장자로 변경하였습니다.